### PR TITLE
Change non-variable height value to float

### DIFF
--- a/habamax-theme.el
+++ b/habamax-theme.el
@@ -39,12 +39,12 @@
      (color-url-visited "#806088")
      (color-bg-highlight "#ececef")
      (color-bg-highlight-2 "#cadfca")
-     (height-1 (if habamax-theme-variable-heading-heights 1.6 1))
-     (height-2 (if habamax-theme-variable-heading-heights 1.4 1))
-     (height-3 (if habamax-theme-variable-heading-heights 1.2 1))
-     (height-4 (if habamax-theme-variable-heading-heights 1.1 1))
-     (height-5 (if habamax-theme-variable-heading-heights 1.1 1))
-     (height-6 (if habamax-theme-variable-heading-heights 1.1 1)))
+     (height-1 (if habamax-theme-variable-heading-heights 1.6 1.0))
+     (height-2 (if habamax-theme-variable-heading-heights 1.4 1.0))
+     (height-3 (if habamax-theme-variable-heading-heights 1.2 1.0))
+     (height-4 (if habamax-theme-variable-heading-heights 1.1 1.0))
+     (height-5 (if habamax-theme-variable-heading-heights 1.1 1.0))
+     (height-6 (if habamax-theme-variable-heading-heights 1.1 1.0)))
 
   (custom-theme-set-faces
    'habamax


### PR DESCRIPTION
An integer for the value of text height on GTK3 treats the height value as an absolute text value size, so org headers (for example) will end up at a font size of 1 instead of 100%.

This PR fixes very, very tiny Org headers when using non-variable text heights.  I don't have a computer running Windows to test this on to see if it breaks anything else.

BTW, enjoying this boring theme! :)